### PR TITLE
back to previous surface, and ratio compensate changes

### DIFF
--- a/scripts/stanncam/stanncam.gml
+++ b/scripts/stanncam/stanncam.gml
@@ -394,7 +394,7 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 	/// @returns {Real}
 	/// @ignore
 	static get_mouse_x = function(){
-		var _mouse_x = (((display_mouse_get_x() - window_get_x() - stanncam_fullscreen_ratio_compensate_x()) / (__obj_stanncam_manager.__display_scale_x * width)) * width * get_zoom_x()) + get_x();
+		var _mouse_x = (((display_mouse_get_x() - window_get_x() - stanncam_ratio_compensate_x()) / (__obj_stanncam_manager.__display_scale_x * width)) * width * get_zoom_x()) + get_x();
 		if(smooth_draw) return _mouse_x;
 		return _mouse_x - (_mouse_x mod get_zoom_x());
 	}
@@ -404,7 +404,7 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 	/// @returns {Real}
 	/// @ignore
 	static get_mouse_y = function(){
-		var _mouse_y = (((display_mouse_get_y() - window_get_y() - stanncam_fullscreen_ratio_compensate_y()) / (__obj_stanncam_manager.__display_scale_y * height)) * height * get_zoom_y()) + get_y();
+		var _mouse_y = (((display_mouse_get_y() - window_get_y() - stanncam_ratio_compensate_y()) / (__obj_stanncam_manager.__display_scale_y * height)) * height * get_zoom_y()) + get_y();
 		if(smooth_draw) return _mouse_y;
 		return _mouse_y - (_mouse_y mod get_zoom_y());
 	}
@@ -523,9 +523,11 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 		if(surface_extra_on){
 			surface_copy(surface_extra, 0, 0, surface);
 		}
+		
+		var old_target = surface_get_target();
 		surface_set_target(surface);
 		draw_clear_alpha(c_black, 0);
-		surface_reset_target();
+		__reset_surface(old_target)
 		view_set_surface_id(cam_id, surface);
 	}
 	
@@ -602,6 +604,16 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 		
 		camera_set_view_pos(__camera, _new_x, _new_y);
 	}
+	
+	/// @function __reset_surface
+	/// @description checks supplied surface,  and goes back to it if it exists, else runs  reset_surface_target
+	/// @ignore
+	static __reset_surface = function(prev_surface){
+		surface_reset_target();
+		if(surface_exists(prev_surface)){
+			surface_set_target(prev_surface)
+		}
+	}
 #endregion
 
 #region Drawing functions
@@ -613,6 +625,7 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 		if(debug_draw){
 			//draws camera bounding box
 			if(follow != -1){
+				var old_target = surface_get_target();
 				surface_set_target(surface);
 				
 				var _pre_color = draw_get_color();
@@ -648,7 +661,7 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 				}
 				
 				draw_set_color(_pre_color);
-				surface_reset_target();
+				__reset_surface(old_target);
 			}
 		}
 	}
@@ -664,6 +677,19 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 		__check_surface();
 		__debug_draw();
 		draw_surf(surface, _x, _y, _scale_x, _scale_y, 0, 0, width, height);
+	}
+	
+	/// @function draw_no_compensate
+	/// @description draws stanncam but without being offset by stanncam_ratio_compensate
+	/// @param {Real} _x
+	/// @param {Real} _y
+	/// @param {Real} [_scale_x=1]
+	/// @param {Real} [_scale_y=1]
+	/// @ignore
+	static draw_no_compensate = function(_x, _y, _scale_x=1, _scale_y=1){
+		__check_surface();
+		__debug_draw();
+		draw_surf(surface, _x, _y, _scale_x, _scale_y, 0, 0, width, height, false);
 	}
 	
 	/// @function draw_part
@@ -704,10 +730,14 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 		if(!surface_exists(__surface_special)){
 			__surface_special = surface_create(_surf_width_scaled, _surf_height_scaled);
 		}
+		
+		var old_target = surface_get_target();
+		
 		surface_set_target(__surface_special);
 		draw_clear_alpha(c_black, 0);
 		_draw_func();
-		surface_reset_target();
+		__reset_surface(old_target);
+		
 		draw_surf(__surface_special, _x, _y, _scale_x, _scale_y, 0, 0, _surf_width, _surf_height);
 	}
 	
@@ -722,14 +752,17 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 	/// @param {Real} [_top=0]
 	/// @param {Real} [_width=surface_get_width(_surface)]
 	/// @param {Real} [_height=surface_get_height(_surface)]
+	/// @param {Bool} [_ratio_compensate=true]
 	/// @ignore
-	static draw_surf = function(_surface, _x, _y, _scale_x=1, _scale_y=1, _left=0, _top=0, _width=surface_get_width(_surface), _height=surface_get_height(_surface)){
+	static draw_surf = function(_surface, _x, _y, _scale_x=1, _scale_y=1, _left=0, _top=0, _width=surface_get_width(_surface), _height=surface_get_height(_surface), _ratio_compensate = true){
 		//offsets position to match with display resoultion
 		_x *= (global.res_w / global.game_w);
 		_y *= (global.res_h / global.game_h);
 		
-		_x += stanncam_fullscreen_ratio_compensate_x();
-		_y += stanncam_fullscreen_ratio_compensate_y();
+		if(_ratio_compensate){
+			_x += stanncam_ratio_compensate_x();
+			_y += stanncam_ratio_compensate_y();
+		}
 		
 		if(smooth_draw){
 		//draws super smooth both when moving and zooming

--- a/scripts/stanncam_manager/stanncam_manager.gml
+++ b/scripts/stanncam_manager/stanncam_manager.gml
@@ -116,20 +116,20 @@ function stanncam_get_keep_aspect_ratio(){
 	return __obj_stanncam_manager.keep_aspect_ratio;
 }
 
-/// @function stanncam_fullscreen_ratio_compensate_x
-/// @description if fullscreen keep_aspect_ratio is on it offsets the x value so the render is in the middle
+/// @function stanncam_ratio_compensate_x
+/// @description if keep_aspect_ratio is on it offsets the x value so the render is in the middle
 /// @returns {Real}
-function stanncam_fullscreen_ratio_compensate_x(){
+function stanncam_ratio_compensate_x(){
 	if(stanncam_get_keep_aspect_ratio()){
 		return (window_get_width() - (global.game_w * __obj_stanncam_manager.__display_scale_x)) * 0.5;
 	}
 	return 0;
 }
 
-/// @function stanncam_fullscreen_ratio_compensate_y
-/// @description if fullscreen keep_aspect_ratio is on it offsets the y value so the render is in the middle
+/// @function stanncam_ratio_compensate_y
+/// @description if keep_aspect_ratio is on it offsets the y value so the render is in the middle
 /// @returns {Real}
-function stanncam_fullscreen_ratio_compensate_y(){
+function stanncam_ratio_compensate_y(){
 	if(stanncam_get_keep_aspect_ratio()){
 		return (window_get_height() - (global.game_h * __obj_stanncam_manager.__display_scale_y)) * 0.5;
 	}
@@ -245,7 +245,7 @@ function __stanncam_update_resolution(){
 			var _gui_x_scale = global.res_w / global.gui_w;
 			var _gui_y_scale = global.res_h / global.gui_h;
 		}
-		display_set_gui_maximize(_gui_x_scale, _gui_y_scale, stanncam_fullscreen_ratio_compensate_x(), stanncam_fullscreen_ratio_compensate_y());
+		display_set_gui_maximize(_gui_x_scale, _gui_y_scale, stanncam_ratio_compensate_x(), stanncam_ratio_compensate_y());
 	}
 }
 


### PR DESCRIPTION
made drawing reset back to previous surface instead of just surface_reset_target
fixes https://github.com/jack27121/STANNcam/issues/33

also changed the name of stanncam_fullscreen_ratio_compensate to just stanncam_ratio_compensate

since it has nothing to do with fullscreen anymore.

also added a .draw_no_compensate function to draw without those ratio compensations. Effectively not drawing in the middle of the screen, but at the 0,0 position