### PR TITLE
mouse_get_x/y fix

### DIFF
--- a/objects/obj_camera_pixel_grid/Draw_64.gml
+++ b/objects/obj_camera_pixel_grid/Draw_64.gml
@@ -29,3 +29,10 @@ switch (global.window_mode) {
 }
 
 draw_text_outline(global.gui_w - 1, _offset * 3, "window mode: " + _window_mode_text + " [F4]", _outline_width, _precision);
+
+var mx = cam1.room_to_gui_x(cam1.get_mouse_x());
+var my = cam1.room_to_gui_y(cam1.get_mouse_y());
+draw_set_halign(fa_left);
+draw_text(mx,my,$"{mx} {my}");
+
+

--- a/scripts/stanncam/stanncam.gml
+++ b/scripts/stanncam/stanncam.gml
@@ -394,7 +394,7 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 	/// @returns {Real}
 	/// @ignore
 	static get_mouse_x = function(){
-		var _mouse_x = (((display_mouse_get_x() - window_get_x() - stanncam_ratio_compensate_x()) / (__obj_stanncam_manager.__display_scale_x * width)) * width * get_zoom_x()) + get_x();
+		var _mouse_x = (((window_mouse_get_x() - stanncam_ratio_compensate_x()) / (__obj_stanncam_manager.__display_scale_x * width)) * width * get_zoom_x()) + get_x();
 		if(smooth_draw) return _mouse_x;
 		return _mouse_x - (_mouse_x mod get_zoom_x());
 	}
@@ -404,7 +404,7 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 	/// @returns {Real}
 	/// @ignore
 	static get_mouse_y = function(){
-		var _mouse_y = (((display_mouse_get_y() - window_get_y() - stanncam_ratio_compensate_y()) / (__obj_stanncam_manager.__display_scale_y * height)) * height * get_zoom_y()) + get_y();
+		var _mouse_y = (((window_mouse_get_y() - stanncam_ratio_compensate_y()) / (__obj_stanncam_manager.__display_scale_y * height)) * height * get_zoom_y()) + get_y();
 		if(smooth_draw) return _mouse_y;
 		return _mouse_y - (_mouse_y mod get_zoom_y());
 	}


### PR DESCRIPTION
was errors on mac before, and it was maybe just bad methods i used before, now it uses `window_mouse_get_x / y` internally
fixes https://github.com/jack27121/STANNcam/issues/30

I had Tom from Juju kitchen test it on mac briefly, works fine for them as well