### PR TITLE
improved movement and simplified zooming

### DIFF
--- a/scripts/stanncam/stanncam.gml
+++ b/scripts/stanncam/stanncam.gml
@@ -161,7 +161,6 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 			__xTo = follow.x;
 			__yTo = follow.y;
 			
-
 			var _x_dist = __xTo - x;
 			var _y_dist = __yTo - y;
 			
@@ -171,17 +170,17 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 			bounds_dist_w = round(bounds_dist_w * 100) / 100 //rounds to 2 decimal places
 			bounds_dist_h = round(bounds_dist_h * 100) / 100 //more decimal places makes the position flbbbbare up at certain points
 			
-			show_debug_message($"w: {bounds_dist_w} h: {bounds_dist_h}");
-			
 			//update camera position
 			if(abs(__xTo - x) > bounds_w){
-				var _spd = (bounds_dist_w / spd_threshold) * spd;
+				var _spd = (bounds_dist_w / spd_threshold) * spd;				
+				if(smooth_draw) _spd = round(_spd);
 				
 				x += _spd;
 			}
 			
 			if(abs(y - __yTo) > bounds_h){
 				var _spd = (bounds_dist_h / spd_threshold) * spd;
+				if(smooth_draw) _spd = round(_spd);
 				
 				y += _spd;
 			}				

--- a/scripts/stanncam/stanncam.gml
+++ b/scripts/stanncam/stanncam.gml
@@ -172,7 +172,7 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 			
 			//update camera position
 			if(abs(__xTo - x) > bounds_w){
-				var _spd = (bounds_dist_w / spd_threshold) * spd;				
+				var _spd = (bounds_dist_w / spd_threshold) * spd;
 				if(smooth_draw) _spd = round(_spd);
 				
 				x += _spd;
@@ -183,7 +183,7 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 				if(smooth_draw) _spd = round(_spd);
 				
 				y += _spd;
-			}				
+			}
 		
 		} else if(__moving){
 			__t++;
@@ -376,7 +376,7 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 	static zoom = function(_zoom, _duration=0){
 		if(_duration == 0){ //if duration is 0 the view is updated immediately
 			zoom_amount = _zoom;
-			if(!get_paused()) {
+			if(!get_paused()){
 				__update_view_size();
 			}
 		} else {
@@ -428,20 +428,20 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 	/// @function set_paused
 	/// @description sets camera paused state
 	/// @param {Bool} _paused
-	static set_paused = function(_paused) {
+	static set_paused = function(_paused){
 		paused = _paused;
 	}
 
 	/// @function get_paused
 	/// @description gets camera's paused state
 	/// @returns {Bool}
-	static get_paused = function() {
+	static get_paused = function(){
 		return paused;
 	}
 
 	/// @function toggle_paused
 	/// @description toggles the camera's paused state
-	static toggle_paused = function() {
+	static toggle_paused = function(){
 		set_paused(!get_paused());
 	}
 
@@ -618,9 +618,9 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 	/// @description updates the view size
 	/// @param {Bool} [_force=false]
 	/// @ignore
-	static __update_view_size = function(_force=false){		
+	static __update_view_size = function(_force=false){
 		//ensures the new surface size is a whole number
-		var _new_width  = (width * zoom_amount); 
+		var _new_width  = (width * zoom_amount);
 		var _new_height = (height * zoom_amount);
 		
 		var _width_2px = _new_width mod 2;
@@ -652,7 +652,7 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 		_new_x -= zoom_x;
 		_new_y -= zoom_y;
 				
-		//zone constricting	
+		//zone constricting
 		if(__zone != noone){
 			var _zone_constrain_x = 0;
 			var _zone_constrain_y = 0;
@@ -675,7 +675,7 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 			//horizontal check
 			if(__zone.sprite_width <= (width * zoom_amount) && __zone.left && __zone.right){
 				//if the zones width is smaller than the camera and both left and right are constraining the cam will be pushed to its middle
-				_zone_constrain_x = (__zone.x+__zone.sprite_width/2) - (_new_x+(width*zoom_amount)/2);
+				_zone_constrain_x = (__zone.x + __zone.sprite_width * 0.5) - (_new_x + (width * zoom_amount) * 0.5);
 			} else {
 				if(__zone.left)  _zone_constrain_x += _left;
 				if(__zone.right) _zone_constrain_x += _right;
@@ -683,7 +683,7 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 			
 			//vertical check
 			if(__zone.sprite_height <= (height * zoom_amount) && __zone.top && __zone.bottom){
-				_zone_constrain_y = (__zone.y+__zone.sprite_height/2) - (_new_y+(height*zoom_amount)/2);
+				_zone_constrain_y = (__zone.y + __zone.sprite_height * 0.5) - (_new_y + (height * zoom_amount) * 0.5);
 			} else {
 				if(__zone.top)	_zone_constrain_y += _top;
 				if(__zone.bottom) _zone_constrain_y += _bottom;
@@ -887,7 +887,7 @@ function stanncam(_x=0, _y=0, _width=global.game_w, _height=global.game_h, _surf
 	 * @function toString
 	 * @returns {String}
 	 */
-	static toString = function() {
+	static toString = function(){
 		return "<stanncam[" + string(cam_id) + "] (" + string(width) + ", " + string(height) + ")>";
 	}
 

--- a/scripts/stanncam_manager/stanncam_manager.gml
+++ b/scripts/stanncam_manager/stanncam_manager.gml
@@ -63,12 +63,12 @@ function stanncam_init(_game_w, _game_h, _resolution_w=_game_w, _resolution_h=_g
 /// @function stanncam_destroy
 /// @description removes all stanncam references from the game, the opposite of stanncam_init
 /// @param {Bool} [_application_surface_draw_enable=true]
-function stanncam_destroy(_application_surface_draw_enable = true){
+function stanncam_destroy(_application_surface_draw_enable=true){
 	application_surface_draw_enable(_application_surface_draw_enable);
 	
-	time_source_destroy(global.stanncam_time_source,true);	
-	for (var i = 0; i < array_length(global.stanncams); ++i) {
-		if(global.stanncams[i] != -1) {
+	time_source_destroy(global.stanncam_time_source,true);
+	for (var i = 0; i < array_length(global.stanncams); ++i){
+		if(global.stanncams[i] != -1){
 			global.stanncams[i].destroy();
 		}
 	}
@@ -353,7 +353,7 @@ function stanncam_debug_set_draw_zones(_should_draw){
 
 /// @function stanncam_toggle_cameras_paused
 /// @description toggles camera's paused state
-function stanncam_toggle_cameras_paused() {
+function stanncam_toggle_cameras_paused(){
 	var _len = array_length(global.stanncams);
 	for (var i = 0; i < _len; ++i){
 		var _camera = global.stanncams[i];
@@ -366,7 +366,7 @@ function stanncam_toggle_cameras_paused() {
 /// @function stanncam_set_cameras_paused
 /// @description sets all cameras to paused state
 /// @param {Bool} _paused
-function stanncam_set_cameras_paused(_paused) {
+function stanncam_set_cameras_paused(_paused){
 	var _len = array_length(global.stanncams);
 	for (var i = 0; i < _len; ++i){
 		var _camera = global.stanncams[i];
@@ -378,12 +378,12 @@ function stanncam_set_cameras_paused(_paused) {
 
 /// @function stanncam_cameras_pause
 /// @description sets all cameras to paused state
-function stanncam_cameras_pause() {
+function stanncam_cameras_pause(){
 	return stanncam_set_cameras_paused(true);
 }
 
 /// @function stanncam_cameras_unpause
 /// @description sets all cameras to an unpaused state
-function stanncam_cameras_unpause() {
+function stanncam_cameras_unpause(){
 	return stanncam_set_cameras_paused(false);
 }


### PR DESCRIPTION
without debug draw now still appears relatively smooth,
also simplified zoom code, so there's no difference in zooming between smooth_draw and not

![Runner_PgLK7BCJrf](https://github.com/jack27121/STANNcam/assets/46312671/c503fdb5-03a2-4f11-8f23-c58a625ec3f5)

fixes https://github.com/jack27121/STANNcam/issues/74
